### PR TITLE
fix: JCE installation error

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,4 +1,5 @@
 galaxy_info:
+  role_name: java
   author: Moshe Immerman
   description: Installs Oracle JDK 8
   license: MIT

--- a/tasks/install_jce.yml
+++ b/tasks/install_jce.yml
@@ -12,11 +12,7 @@
       changed_when: False
 
     - name: install JCE
-      unarchive:
-          src: /tmp/unlimited_jce.zip
-          dest: "{{JVM_PATH}}/jre/lib/security/"
-          extra_opts: -j
-
+      shell: "unzip -jo /tmp/unlimited_jce.zip -d {{JVM_PATH}}/jre/lib/security/"
       when: not jce.stat.exists
 
     - name: remove installation file


### PR DESCRIPTION
..saying:
```
TASK [moshloop.java : install JCE] ************************************************************************************************************************************************************************************************************************************
fatal: [localhost]: FAILED! => {"changed": true, "dest": "/usr/lib/jvm/java-8-oracle/jre/lib/security/", "extract_results": {"cmd": ["/usr/bin/unzip", "-o", "-jo", "/root/.ansible/tmp/ansible-tmp-1538492767.05-57594031139167/source", "-d", "/usr/lib/jvm/java-8-oracle/jre/lib/security/"], "err": "", "out": "Archive:  /root/.ansible/tmp/ansible-tmp-1538492767.05-57594031139167/source\n  inflating: /usr/lib/jvm/java-8-oracle/jre/lib/security/local_policy.jar  \n  inflating: /usr/lib/jvm/java-8-oracle/jre/lib/security/README.txt  \n  inflating: /usr/lib/jvm/java-8-oracle/jre/lib/security/US_export_policy.jar  \n", "rc": 0}, "failed": true, "gid": 143, "group": "143", "handler": "ZipArchive", "mode": "0755", "msg": "Unexpected error when accessing exploded file: [Errno 2] No such file or directory: '/usr/lib/jvm/java-8-oracle/jre/lib/security/UnlimitedJCEPolicyJDK8/'", "owner": "uucp", "size": 4096, "src": "/root/.ansible/tmp/ansible-tmp-1538492767.05-57594031139167/source", "state": "directory", "uid": 10}
```

..which is quite weird considering that the commands should be equivalent